### PR TITLE
Support Python 3.5

### DIFF
--- a/daskernetes/core.py
+++ b/daskernetes/core.py
@@ -86,7 +86,7 @@ class KubeCluster(object):
             host='0.0.0.0',
             port=0,
             env=None,
-            **kwargs,
+            **kwargs
     ):
         self.cluster = LocalCluster(ip=host or socket.gethostname(),
                                     scheduler_port=port,


### PR DESCRIPTION
Also change testing from 3.6 to 3.5.
At some point we should test both, but until then 3.5 is probably safer,
because of backwards compatibility.