### PR TITLE
Add generic scale (up or down) function

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -75,7 +75,7 @@ API Documentation
    KubeCluster.from_yaml
    KubeCluster.logs
    KubeCluster.pods
-   KubeCluster.scale_up
+   KubeCluster.scale
 
 .. autoclass:: KubeCluster
    :members:


### PR DESCRIPTION
Previously we could only scale up by number of workers.
To scale down we needed to specify the precise workers to kill
(this was normally handled by the scheduler in adaptive mode).
However sometimes you just want to manually control the size of the
cluster.

This implements a simple heuristic, to first choose the idle workers
then then prefer workers with less memory use.