### PR TITLE
Automatically read worker yaml file from env variable

### DIFF
--- a/daskernetes/__init__.py
+++ b/daskernetes/__init__.py
@@ -1,3 +1,4 @@
+from .config import config
 from .core import KubeCluster
 from .objects import make_pod_spec, make_pod_from_dict
 

--- a/daskernetes/config.py
+++ b/daskernetes/config.py
@@ -1,0 +1,5 @@
+import os
+
+config = {'-'.join(k.split('_')[1:]).lower(): v
+          for k, v in os.environ.items()
+          if k.startswith('DASKERNETES_')}

--- a/daskernetes/config.py
+++ b/daskernetes/config.py
@@ -1,3 +1,17 @@
+"""
+We capture all environment variables named
+
+    DASKERNETES_FOO_BAR=value
+
+And turn them into key-value pairs in a global ``config`` dictionary.
+We change the keys to remove ``DASKERNETES_``, replace underscores with
+hyphens, and lower-case the entire thing.  This results in a Python dictionary
+like the following:
+
+    >>> config
+    {'foo-bar': 'value'}
+"""
+
 import os
 
 config = {'-'.join(k.split('_')[1:]).lower(): v

--- a/daskernetes/core.py
+++ b/daskernetes/core.py
@@ -15,9 +15,10 @@ from tornado import gen
 from tornado.ioloop import IOLoop
 
 from distributed.deploy import LocalCluster
-from kubernetes import client, config
+import kubernetes
 
-from daskernetes.objects import make_pod_from_dict, clean_pod_template
+from .config import config
+from .objects import make_pod_from_dict, clean_pod_template
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +116,7 @@ class KubeCluster(object):
     """
     def __init__(
             self,
-            pod_template,
+            pod_template=None,
             name=None,
             namespace=None,
             n_workers=0,
@@ -124,15 +125,26 @@ class KubeCluster(object):
             env=None,
             **kwargs
     ):
+        if pod_template is None:
+            if 'worker-spec-path' in config:
+                import yaml
+                with open(config['worker-spec-path']) as f:
+                    d = yaml.safe_load(f)
+                pod_template = make_pod_from_dict(d)
+            else:
+                msg = ("Worker pod specification not provided. See KubeCluster "
+                       "docstring for ways to specify workers")
+                raise ValueError(msg)
+
         self.cluster = LocalCluster(ip=host or socket.gethostname(),
                                     scheduler_port=port,
                                     n_workers=0, **kwargs)
         try:
-            config.load_incluster_config()
-        except config.ConfigException:
-            config.load_kube_config()
+            kubernetes.config.load_incluster_config()
+        except kubernetes.config.ConfigException:
+            kubernetes.config.load_kube_config()
 
-        self.core_api = client.CoreV1Api()
+        self.core_api = kubernetes.client.CoreV1Api()
 
         if namespace is None:
             namespace = _namespace_default()
@@ -148,11 +160,12 @@ class KubeCluster(object):
         self.pod_template.metadata.namespace = namespace
 
         self.pod_template.spec.containers[0].env.append(
-            client.V1EnvVar(name='DASK_SCHEDULER_ADDRESS', value=self.scheduler_address)
+            kubernetes.client.V1EnvVar(name='DASK_SCHEDULER_ADDRESS',
+                                       value=self.scheduler_address)
         )
         if env:
             self.pod_template.spec.containers[0].env.extend([
-                client.V1EnvVar(name=k, value=str(v))
+                kubernetes.client.V1EnvVar(name=k, value=str(v))
                 for k, v in env.items()
             ])
         self.pod_template.metadata.generate_name = name
@@ -343,7 +356,7 @@ class KubeCluster(object):
                     for _ in range(n - len(pods))
                 ]
                 break
-            except client.rest.ApiException as e:
+            except kubernetes.client.rest.ApiException as e:
                 if e.status == 500 and 'ServerTimeout' in e.body:
                     logger.info("Server timeout, retry #%d", i + 1)
                     time.sleep(1)
@@ -386,10 +399,10 @@ class KubeCluster(object):
                 self.core_api.delete_namespaced_pod(
                     pod.metadata.name,
                     self.namespace,
-                    client.V1DeleteOptions()
+                    kubernetes.client.V1DeleteOptions()
                 )
                 logger.info('Deleted pod: %s', pod.metadata.name)
-            except client.rest.ApiException as e:
+            except kubernetes.client.rest.ApiException as e:
                 # If a pod has already been removed, just ignore the error
                 if e.status != 404:
                     raise
@@ -425,14 +438,14 @@ class KubeCluster(object):
 
 def _cleanup_pods(namespace, labels):
     """ Remove all pods with these labels in this namespace """
-    api = client.CoreV1Api()
+    api = kubernetes.client.CoreV1Api()
     pods = api.list_namespaced_pod(namespace, label_selector=format_labels(labels))
     for pod in pods.items:
         try:
             api.delete_namespaced_pod(pod.metadata.name, namespace,
-                                      client.V1DeleteOptions())
+                                      kubernetes.client.V1DeleteOptions())
             logger.info('Deleted pod: %s', pod.metadata.name)
-        except client.rest.ApiException as e:
+        except kubernetes.client.rest.ApiException as e:
             # ignore error if pod is already removed
             if e.status != 404:
                 raise

--- a/daskernetes/core.py
+++ b/daskernetes/core.py
@@ -76,7 +76,7 @@ class KubeCluster(object):
     You can also create clusters with worker pod specifications as dictionaries
     or stored in YAML files
 
-    >>> cluster = KubeCluster.from_yaml('worker-spec.yml')
+    >>> cluster = KubeCluster.from_yaml('worker-template.yml')
     >>> cluster = KubeCluster.from_dict({...})
 
     Rather than explicitly setting a number of workers you can also ask the
@@ -108,6 +108,14 @@ class KubeCluster(object):
     >>> KubeCluster.from_yaml(..., env={'EXTRA_PIP_PACKAGES': pip,
     ...                                 'ExtRA_CONDA_PACKAGES': conda})
 
+    You can also start a KubeCluster with no arguments *if* the YAML file
+    defining the worker template is referred to in the
+    ``DASKERNETES_WORKER_TEMPLATE_PATH`` environment variable
+
+        $ export DASKERNETES_WORKER_TEMPLATE_PATH=worker_template.yaml
+
+    >>> cluster = KubeCluster()  # automatically finds 'worker_template.yaml'
+
     See Also
     --------
     KubeCluster.from_yaml
@@ -126,9 +134,9 @@ class KubeCluster(object):
             **kwargs
     ):
         if pod_template is None:
-            if 'worker-spec-path' in config:
+            if 'worker-template-path' in config:
                 import yaml
-                with open(config['worker-spec-path']) as f:
+                with open(config['worker-template-path']) as f:
                     d = yaml.safe_load(f)
                 pod_template = make_pod_from_dict(d)
             else:
@@ -429,7 +437,7 @@ class KubeCluster(object):
 
         Examples
         --------
-        >>> cluster = KubeCluster.from_yaml('worker-spec.yaml')
+        >>> cluster = KubeCluster.from_yaml('worker-template.yaml')
         >>> cluster.adapt()
         """
         from distributed.deploy import Adaptive

--- a/daskernetes/tests/test_core.py
+++ b/daskernetes/tests/test_core.py
@@ -309,9 +309,9 @@ def test_automatic_startup(image_name, loop, ns):
     with tmpfile(extension='yaml') as fn:
         with open(fn, mode='w') as f:
             yaml.dump(test_yaml, f)
-        config['worker-spec-path'] = fn
+        config['worker-template-path'] = fn
         try:
             with KubeCluster(loop=loop, namespace=ns) as cluster:
                 assert cluster.pod_template.metadata.labels['foo'] == 'bar'
         finally:
-            del config['worker-spec-path']
+            del config['worker-template-path']

--- a/daskernetes/tests/test_core.py
+++ b/daskernetes/tests/test_core.py
@@ -5,8 +5,7 @@ import uuid
 import yaml
 
 import pytest
-from daskernetes import KubeCluster
-from daskernetes.objects import make_pod_spec
+from daskernetes import KubeCluster, make_pod_spec, config
 from dask.distributed import Client, wait
 from distributed.utils_test import loop, inc  # noqa: F401
 from distributed.utils import tmpfile
@@ -283,3 +282,36 @@ def test_scale_up_down(cluster, client):
         assert time() < start + 10
 
     assert set(cluster.scheduler.workers) == {b}
+
+
+def test_automatic_startup(image_name, loop, ns):
+    test_yaml = {
+        "kind": "Pod",
+        "metadata": {
+            "labels": {
+                "foo": "bar",
+            }
+        },
+        "spec": {
+            "containers": [{
+                "args": [
+                    "dask-worker",
+                    "$(DASK_SCHEDULER_ADDRESS)",
+                    "--nthreads",
+                    "1"
+                ],
+                "image": image_name,
+                "name": "dask-worker"
+            }]
+        }
+    }
+
+    with tmpfile(extension='yaml') as fn:
+        with open(fn, mode='w') as f:
+            yaml.dump(test_yaml, f)
+        config['worker-spec-path'] = fn
+        try:
+            with KubeCluster(loop=loop, namespace=ns) as cluster:
+                assert cluster.pod_template.metadata.labels['foo'] == 'bar'
+        finally:
+            del config['worker-spec-path']


### PR DESCRIPTION
This allows users to launch a KubeCluster() with no arguments if the
worker pod spec is in a yaml file pointed to by
the DASKERNETES_WORKER_SPEC_PATH environment variable.

This commit also creates a config.py file that contains daskernetes
configuration, which is currently just taken from environment variables.