### PR TITLE
Set diagnostics link with environment variable

### DIFF
--- a/daskernetes/core.py
+++ b/daskernetes/core.py
@@ -263,10 +263,27 @@ class KubeCluster(object):
         import ipywidgets
         layout = ipywidgets.Layout(width='150px')
 
+        elements = []
+        if 'bokeh' in self.scheduler.services:
+            if 'diagnostics-link' in config:
+                template = config['diagnostics-link']
+            else:
+                template = 'http://{host}:{port}/status'
+
+            d = {'host': self.scheduler.address.split('://')[1].split(':')[0],
+                 'port': self.scheduler.services['bokeh'].port}
+            d.update(os.environ)
+
+            link = template.format(**d)
+            link = ipywidgets.HTML('<b>Dashboard:</b> <a href="%s" target="_blank">%s</a>' %
+                                   (link, link))
+            elements.append(link)
+
         n_workers = ipywidgets.IntText(0, description='Requested', layout=layout)
         actual = ipywidgets.Text('0', description='Actual', layout=layout)
         button = ipywidgets.Button(description='Scale', layout=layout)
-        box = ipywidgets.VBox([n_workers, actual, button])
+        elements.extend([n_workers, actual, button])
+        box = ipywidgets.VBox(elements)
         self._cached_widget = box
 
         def cb(b):

--- a/daskernetes/core.py
+++ b/daskernetes/core.py
@@ -270,11 +270,9 @@ class KubeCluster(object):
             else:
                 template = 'http://{host}:{port}/status'
 
-            d = {'host': self.scheduler.address.split('://')[1].split(':')[0],
-                 'port': self.scheduler.services['bokeh'].port}
-            d.update(os.environ)
-
-            link = template.format(**d)
+            host = self.scheduler.address.split('://')[1].split(':')[0]
+            port = self.scheduler.services['bokeh'].port
+            link = template.format(host=host, port=port, **os.environ)
             link = ipywidgets.HTML('<b>Dashboard:</b> <a href="%s" target="_blank">%s</a>' %
                                    (link, link))
             elements.append(link)

--- a/daskernetes/tests/test_core.py
+++ b/daskernetes/tests/test_core.py
@@ -94,6 +94,22 @@ def test_ipython_display(cluster):
         sleep(0.5)
 
 
+def test_diagnostics_link_env_variable(pod_spec, loop, ns):
+    pytest.importorskip('bokeh')
+    config['diagnostics-link'] = 'foo-{USER}-{port}'
+    try:
+        with KubeCluster(pod_spec, loop=loop, namespace=ns) as cluster:
+            port = cluster.scheduler.services['bokeh'].port
+            cluster._ipython_display_()
+            box = cluster._cached_widget
+
+            link = box.children[0]
+            assert 'foo-' + getpass.getuser() + '-' + str(port) in link.value
+            assert 'href' in link.value
+    finally:
+        del config['diagnostics-link']
+
+
 def test_namespace(pod_spec, loop, ns):
     with KubeCluster(pod_spec, loop=loop, namespace=ns) as cluster:
         assert 'dask' in cluster.name

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -63,6 +63,29 @@ Considerations
     available memory, leading to ``KilledWorker`` errors.
 
 
+Configuration
+-------------
+
+There are a few special environment variables that affect daskernetes behavior:
+
+1.  ``DASKERNETES_WORKER_TEMPLATE_PATH``: a path a a YAML file that holds a
+    Pod spec for the worker.  If provided then this will be used when
+    :obj:`KubeCluster` is called with no arguments::
+
+       cluster = KubeCluster()  # reads provided yaml file
+
+2.  ``DASKERNETES_DIAGNOSTICS_LINK``: a Python pre-formatted string that shows
+    the location of Dask's dashboard.  This string will receive values for
+    ``host``, ``port``, and all environment variables.  This is useful when
+    using Daskernetes with JupyterHub and nbserverproxy to route the dashboard
+    link to a proxied address as follows::
+
+       export DASKERNETES_DIANGOSTICS_LINK="{JUPYTERHUB_SERVICE_PREFIX}proxy/{port}/status"
+
+Any other environment variable starting with ``DASKERNETES_`` will be placed in
+the ``daskernetes.config`` dictionary for general use.
+
+
 API Documentation
 -----------------
 


### PR DESCRIPTION
This allows us to set the diagnostics link shown in the KubeCluster widget with an arbitrary formatted strings like the following example from a JupyterHub deployment with nbserverproxy running:

    export DASKERNETES_DIAGNOSTICS_LINK="{JUPYTERHUB_SERVICE_PREFIX}proxy/{port}/status"

The widget looks for this environment variable and populates it with `.format(host=host, port=port, **os.environ)`

cc @yuvipanda 