### PR TITLE
Allow customisation of worker name in environment

### DIFF
--- a/daskernetes/core.py
+++ b/daskernetes/core.py
@@ -158,8 +158,8 @@ class KubeCluster(object):
             namespace = _namespace_default()
 
         if name is None:
-            worker_name_template = config.get('worker-name-template', 'dask-{user}-{uuid}')
-            name =  worker_name_template.format(user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **os.environ)
+            worker_name = config.get('worker-name', 'dask-{user}-{uuid}')
+            name =  worker_name.format(user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **os.environ)
 
         self.pod_template = clean_pod_template(pod_template)
         # Default labels that can't be overwritten

--- a/daskernetes/core.py
+++ b/daskernetes/core.py
@@ -159,7 +159,7 @@ class KubeCluster(object):
 
         if name is None:
             worker_name = config.get('worker-name', 'dask-{user}-{uuid}')
-            name =  worker_name.format(user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **os.environ)
+            name = worker_name.format(user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **os.environ)
 
         self.pod_template = clean_pod_template(pod_template)
         # Default labels that can't be overwritten

--- a/daskernetes/core.py
+++ b/daskernetes/core.py
@@ -158,10 +158,7 @@ class KubeCluster(object):
             namespace = _namespace_default()
 
         if name is None:
-            if 'worker-name-template' in config:
-                worker_name_template = config['worker-name-template']
-            else:
-                worker_name_template = 'dask-{user}-{uuid}'
+            worker_name_template = config.get('worker-name-template', 'dask-{user}-{uuid}')
             name =  worker_name_template.format(user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **os.environ)
 
         self.pod_template = clean_pod_template(pod_template)

--- a/daskernetes/core.py
+++ b/daskernetes/core.py
@@ -158,7 +158,11 @@ class KubeCluster(object):
             namespace = _namespace_default()
 
         if name is None:
-            name = 'dask-%s-%s' % (getpass.getuser(), str(uuid.uuid4())[:10])
+            if 'worker-name-template' in config:
+                worker_name_template = config['worker-name-template']
+            else:
+                worker_name_template = 'dask-{user}-{uuid}'
+            name =  worker_name_template.format(user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **os.environ)
 
         self.pod_template = clean_pod_template(pod_template)
         # Default labels that can't be overwritten

--- a/daskernetes/tests/test_core.py
+++ b/daskernetes/tests/test_core.py
@@ -94,13 +94,13 @@ def test_ipython_display(cluster):
         sleep(0.5)
 
 
-def test_dask_worker_name_template_env_variable(pod_spec, loop, ns):
-    config['worker-name-template'] = 'foo-{USER}-{uuid}'
+def test_dask_worker_name_env_variable(pod_spec, loop, ns):
+    config['worker-name'] = 'foo-{USER}-{uuid}'
     try:
         with KubeCluster(pod_spec, loop=loop, namespace=ns) as cluster:
             assert 'foo-' + getpass.getuser() in cluster.name
     finally:
-        del config['worker-name-template']
+        del config['worker-name']
 
 
 def test_diagnostics_link_env_variable(pod_spec, loop, ns):

--- a/daskernetes/tests/test_core.py
+++ b/daskernetes/tests/test_core.py
@@ -94,6 +94,15 @@ def test_ipython_display(cluster):
         sleep(0.5)
 
 
+def test_dask_worker_name_template_env_variable(pod_spec, loop, ns):
+    config['worker-name-template'] = 'foo-{USER}-{uuid}'
+    try:
+        with KubeCluster(pod_spec, loop=loop, namespace=ns) as cluster:
+            assert 'foo-' + getpass.getuser() in cluster.name
+    finally:
+        del config['worker-name-template']
+
+
 def test_diagnostics_link_env_variable(pod_spec, loop, ns):
     pytest.importorskip('bokeh')
     config['diagnostics-link'] = 'foo-{USER}-{port}'

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -89,6 +89,15 @@ There are a few special environment variables that affect daskernetes behavior:
 
        export DASKERNETES_DIANGOSTICS_LINK="{JUPYTERHUB_SERVICE_PREFIX}proxy/{port}/status"
 
+3.  ``DASKERNETES_WORKER_NAME_TEMPLATE``: a Python pre-formatted string to use
+    when naming dask worker pods. This string will receive values for ``user``,
+    ``uuid``, and all environment variables. This is useful when you want to have
+    control over the naming convention for your pods and use other tokens from
+    the environment. For example when using zero-to-jupyterhub every user is
+    called ``jovyan`` and so you may wish to use ``dask-{JUPYTERHUB_USER}-{uuid}``
+    instead of ``dask-{user}-{uuid}``. **Ensure you keep the ``uuid`` somewhere in
+    the template.**
+
 Any other environment variable starting with ``DASKERNETES_`` will be placed in
 the ``daskernetes.config`` dictionary for general use.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -89,7 +89,7 @@ There are a few special environment variables that affect daskernetes behavior:
 
        export DASKERNETES_DIANGOSTICS_LINK="{JUPYTERHUB_SERVICE_PREFIX}proxy/{port}/status"
 
-3.  ``DASKERNETES_WORKER_NAME_TEMPLATE``: a Python pre-formatted string to use
+3.  ``DASKERNETES_WORKER_NAME``: a Python pre-formatted string to use
     when naming dask worker pods. This string will receive values for ``user``,
     ``uuid``, and all environment variables. This is useful when you want to have
     control over the naming convention for your pods and use other tokens from


### PR DESCRIPTION
This PR allows you to customise the worker name template with the environment variable `DASKERNETES_WORKER_NAME_TEMPLATE`. If not specified it falls back to `dask-{user}-{uuid}`.

The template is then formatted with `user` and `uuid` as before but also it unpacks `os.environ` to allow the use of environment variables in the template.

For example in my use case I'm keen to configure the template to `dask-{JUPYTERHUB_USER}-{uuid}` as the `user` is always `jovyan`.